### PR TITLE
CI: Fix galaxy-action default git_branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,3 +73,4 @@ jobs:
         uses: robertdebock/galaxy-action@1.2.1
         with:
           galaxy_api_key: ${{ secrets.galaxy_api_key }}
+          git_branch: main


### PR DESCRIPTION
Hi @justin-p,

it seems that the galaxy action fails silently with return code 128.
IMHO, the problem is that the default `git_branch` variable from plugin is `master` and we have `main` here.

See that the job is actually failing [here](https://github.com/justin-p/ansible-role-chisel/actions/runs/5965895987).