### PR TITLE
Fix chisel-server command flags

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,3 +39,4 @@ chisel_server_backend: http://127.0.0.1:8081
 chisel_server_tls_ca: /path/to/PEM
 chisel_server_tls_key: /path/to/PEM
 chisel_server_tls_cert: /path/to/PEM
+chisel_server_reverse: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,12 +31,12 @@ chisel_client_tls_cert:  /path/to/PEM
 
 chisel_server_host: 0.0.0.0
 chisel_server_port: 80
-chisel_server_key: a_random_string
-chisel_server_auth_file: /path/to/user.json
-chisel_server_auth: user:pass
+chisel_server_key: "" #a_random_string
+chisel_server_auth_file: "" #/path/to/user.json
+chisel_server_auth: "" #user:pass
 chisel_server_keepalive: 25s
 chisel_server_backend: http://127.0.0.1:8081
-chisel_server_tls_ca: /path/to/PEM
-chisel_server_tls_key: /path/to/PEM
-chisel_server_tls_cert: /path/to/PEM
+chisel_server_tls_ca: "" #/path/to/PEM
+chisel_server_tls_key: "" #/path/to/PEM
+chisel_server_tls_cert: "" #/path/to/PEM
 chisel_server_reverse: true

--- a/templates/chisel-server.conf.j2
+++ b/templates/chisel-server.conf.j2
@@ -1,5 +1,6 @@
 # HOST=--host {{ chisel_server_host }}
 PORT=--port {{ chisel_server_port }}
+REVERSE=--reverse
 # KEY=--key {{ chisel_server_key }}
 # AUTH_FILE=--authfile {{ chisel_server_auth_file }}
 # AUTH=--auth {{ chisel_server_auth }}

--- a/templates/chisel-server.conf.j2
+++ b/templates/chisel-server.conf.j2
@@ -2,15 +2,27 @@
 PORT=--port {{ chisel_server_port }}
 {% if chisel_server_reverse %}
 REVERSE=--reverse
-%{ endif %}
-# KEY=--key {{ chisel_server_key }}
-# AUTH_FILE=--authfile {{ chisel_server_auth_file }}
-# AUTH=--auth {{ chisel_server_auth }}
+{% endif %}
+{% if chisel_server_key %}
+KEY=--key {{ chisel_server_key }}
+{% endif %}
+{% if chisel_server_auth_file %}
+AUTH_FILE=--authfile {{ chisel_server_auth_file }}
+{% endif %}
+{% if chisel_server_auth %}
+AUTH=--auth {{ chisel_server_auth }}
+{% endif %}
 # KEEPALIVE=--keepalive {{ chisel_server_keepalive }}
 # BACKEND=--backend {{ chisel_server_backend }}
 # SOCK5=--sock5
-# TLS_CA=--tls-ca {{ chisel_server_tls_ca }}
-# TLS_KEY=--tls-key {{ chisel_server_tls_key }}
-# TLS_CERT=--tls-cert {{ chisel_server_tls_cert }}
+{% if chisel_server_tls_ca %}
+TLS_CA=--tls-ca {{ chisel_server_tls_ca }}
+{% endif %}
+{% if chisel_server_tls_key %}
+TLS_KEY=--tls-key {{ chisel_server_tls_key }}
+{% endif %}
+{%if chisel_server_tls_cert %}
+TLS_CERT=--tls-cert {{ chisel_server_tls_cert }}
+{% endif %}
 # PID=--pid
 VERBOSE=-v

--- a/templates/chisel-server.conf.j2
+++ b/templates/chisel-server.conf.j2
@@ -1,6 +1,8 @@
 # HOST=--host {{ chisel_server_host }}
 PORT=--port {{ chisel_server_port }}
+{% if chisel_server_reverse %}
 REVERSE=--reverse
+%{ endif %}
 # KEY=--key {{ chisel_server_key }}
 # AUTH_FILE=--authfile {{ chisel_server_auth_file }}
 # AUTH=--auth {{ chisel_server_auth }}

--- a/templates/chisel-server.service.j2
+++ b/templates/chisel-server.service.j2
@@ -12,7 +12,7 @@ Restart=always
 StandardOutput=file:/var/log/chisel/{{ chisel_config_name }}.log
 StandardError=file:/var/log/chisel/{{ chisel_config_name }}_error.log
 EnvironmentFile={{ chisel_config_destination }}
-ExecStart=/usr/local/bin/chisel server $HOST $PORT $KEY $AUTH_FILE $AUTH $KEEPALIVE $BACKEND $SOCK5 $TLS_KEY $TLS_CERT $TLS_DOMAIN $TLS_CA $PID $VERBOSE
+ExecStart=/usr/local/bin/chisel server $HOST $PORT $KEY $AUTH_FILE $AUTH $KEEPALIVE $BACKEND $REVERSE $SOCK5 $TLS_KEY $TLS_CERT $TLS_DOMAIN $TLS_CA $PID $VERBOSE
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Add: chisel server --reverse flag
Fixes: flags like auth, authfile, key, and certificates when set were not being used by the service (the entire line was commented). Changed default values to empty, which is not set/false for templating, to enable adding the line only when those flags are needed/set.